### PR TITLE
Handle small class sizes in SMOTE

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,12 +1,19 @@
 from collections import Counter
 from imblearn.over_sampling import SMOTE
 
+
 def apply_safe_smote(X_train, y_train):
     class_counts = Counter(y_train)
+    if not class_counts:
+        return X_train, y_train
+
     min_samples = min(class_counts.values())
 
+    if min_samples <= 1:
+        return X_train, y_train
+
     if min_samples < 6:
-        k_neighbors = min_samples - 1
+        k_neighbors = max(1, min_samples - 1)
         print(f"\nUsing reduced k_neighbors={k_neighbors} for SMOTE due to small class size")
         smote = SMOTE(k_neighbors=k_neighbors, random_state=42)
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from collections import Counter
+
+import numpy as np
+
+# Ensure src is on the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.utils import apply_safe_smote
+
+
+def test_apply_safe_smote_zero_samples():
+    X = np.empty((0, 2))
+    y = np.array([])
+    X_res, y_res = apply_safe_smote(X, y)
+    assert X_res.shape == (0, 2)
+    assert y_res.shape == (0,)
+
+
+def test_apply_safe_smote_one_sample():
+    X = np.array([[1, 2]])
+    y = np.array([0])
+    X_res, y_res = apply_safe_smote(X, y)
+    assert np.array_equal(X_res, X)
+    assert np.array_equal(y_res, y)
+
+
+def test_apply_safe_smote_two_samples():
+    X = np.array(
+        [
+            [0, 0],
+            [0, 1],
+            [1, 0],
+            [1, 1],
+            [2, 0],
+            [2, 1],
+        ]
+    )
+    y = np.array([0, 0, 0, 0, 1, 1])
+    X_res, y_res = apply_safe_smote(X, y)
+    counts = Counter(y_res)
+    assert counts[0] == counts[1] == 4
+    assert len(y_res) > len(y)
+


### PR DESCRIPTION
## Summary
- avoid SMOTE when classes have 0 or 1 samples
- cap k_neighbors to max(1, min_samples - 1)
- add unit tests for class sizes with 0–2 samples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e381dfa08327b8513fbe9008cd62